### PR TITLE
Fix comment parsing

### DIFF
--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -103,6 +103,10 @@ impl Dom {
                 Rule::node_text => {
                     dom.children.push(Node::Text(pair.as_str().to_string()));
                 }
+                Rule::node_comment => {
+                    dom.children
+                        .push(Node::Comment(pair.into_inner().as_str().to_string()));
+                }
                 Rule::EOI => break,
                 _ => unreachable!("[build dom] unknown rule: {:?}", pair.as_rule()),
             };
@@ -173,6 +177,11 @@ impl Dom {
                 }
                 Rule::node_text | Rule::el_raw_text_content => {
                     element.children.push(Node::Text(pair.as_str().to_string()));
+                }
+                Rule::node_comment => {
+                    element
+                        .children
+                        .push(Node::Comment(pair.into_inner().as_str().to_string()));
                 }
                 // TODO: To enable some kind of validation we should probably align this with
                 // https://html.spec.whatwg.org/multipage/syntax.html#elements-2

--- a/src/grammar/rules.pest
+++ b/src/grammar/rules.pest
@@ -18,19 +18,21 @@ doctype = { chevron_left_bang ~ ^"doctype" ~ attr* ~ chevron_right_normal}
 // NODES
 //
 node = _{ node_comment | node_element | node_text }
-node_comment = _{ comment_if | comment_normal }
+node_comment = { comment_if | comment_normal }
 node_text = { (!(node_element | comment_tag_start) ~ ANY)+ }
 node_element = { el_void | el_void_xml | el_process_instruct | el_raw_text | el_normal | el_dangling }
 
 //
 // COMMENTS
 //
-comment_normal = _{ comment_tag_start ~ (!comment_tag_end ~ ANY)* ~ comment_tag_end }
+comment_normal = _{ comment_tag_start ~ comment_body ~ comment_tag_end }
+comment_body = { (!comment_tag_end ~ ANY)* }
 comment_tag_start = _{ chevron_left_bang ~ "--" }
 comment_tag_end = _{ "--" ~ chevron_right_normal }
 
 // Compatability with old IE browsers... This is not necessary for newer browsers
-comment_if = _{ comment_if_start ~ (!comment_if_end ~ ANY)* ~ comment_if_end }
+comment_if = _{ comment_if_start ~ comment_if_body ~ comment_if_end }
+comment_if_body = { (!comment_if_end ~ ANY)* }
 comment_if_start = _{ comment_tag_start ~ "[" ~ ^"if" }
 comment_if_end = _{ chevron_left_bang ~ "[" ~ ^"endif" ~ "]" ~ comment_tag_end }
 


### PR DESCRIPTION
Change the grammar to emit a token for a comment, with a separate token
containing the text of the comment.  Modify build_dom and
build_node_element to handle these new tokens.

In JSON format, text and comments are indistinguishable.  But the code
has been tested to prove that it does emit different Node enum variants.