### PR TITLE
Adding information about the span of an element in the original sourc…

### DIFF
--- a/src/dom/element.rs
+++ b/src/dom/element.rs
@@ -1,4 +1,5 @@
 use super::node::Node;
+use super::span::SourceSpan;
 use serde::{Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
 use std::default::Default;
@@ -43,6 +44,10 @@ pub struct Element {
     /// All of the elements child nodes
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<Node>,
+
+    /// Span of the element in the parsed source
+    #[serde(skip)]
+    pub source_span: SourceSpan
 }
 
 impl Default for Element {
@@ -54,6 +59,7 @@ impl Default for Element {
             classes: vec![],
             attributes: HashMap::new(),
             children: vec![],
+            source_span: SourceSpan::default()
         }
     }
 }

--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -238,8 +238,8 @@ impl Dom {
             SourceSpan::new(
                 String::from(pair_span.as_str()),
                 start_line,
-                start_column,
                 end_line,
+                start_column,
                 end_column
             )
         };

--- a/src/dom/span.rs
+++ b/src/dom/span.rs
@@ -1,0 +1,30 @@
+use serde::{Serialize};
+
+/// Span of the information in the parsed source.
+#[derive(Debug, Default, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceSpan {
+    pub text: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub start_column: usize,
+    pub end_column: usize,
+}
+
+impl SourceSpan {
+    pub fn new(
+        text: String,
+        start_line: usize,
+        end_line: usize,
+        start_column: usize,
+        end_column: usize,
+    ) -> Self {
+        Self {
+            text,
+            start_line,
+            end_line,
+            start_column,
+            end_column,
+        }
+    }
+}


### PR DESCRIPTION
…e the element has been parsed from

Regarding issue #13 

Also needed this and figured I could implement it myself.
I guess there are sill tests needed.. currently just skipped serialization of the `source_span` field in the the `Element` struct so that the tests would succeed.

Maybe you could point me in the right direction of things that would still be needed!
Looking forward to your code review!