### PR TITLE
don't trim empty text elements

### DIFF
--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -131,7 +131,7 @@ impl Dom {
                         dom.tree_type = DomVariant::DocumentFragment;
                     }
                     let text = pair.as_str().to_string();
-                    if !text.trim().is_empty() {
+                    if !text.is_empty() {
                         dom.children.push(Node::Text(text));
                     }
                 }
@@ -268,7 +268,7 @@ impl Dom {
                 }
                 Rule::node_text | Rule::el_raw_text_content => {
                     let text = pair.as_str().to_string();
-                    if !text.trim().is_empty() {
+                    if !text.is_empty() {
                         element.children.push(Node::Text(text));
                     }
                 }


### PR DESCRIPTION
Hey there :) 

I have a pipeline like 
```
markdown -> [comrak] -> html
html -> [html-parser] -> nodes
nodes -> [my-logic] -> html
html
```

And, it took me a while to figure it out why my code blocks were broken! (Missing tabs, missing newlines, ...) 😅 

Finally I realized that empty text blocks are not parsed by html-parsed, but they were not "empty", they were "whitespace only", which are still important inside `<pre>` so I don't think we should get rid of them this easily!

I tested this PR on my repos and it fixes my problem.