### PR TITLE
Make SourceSpan public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ use grammar::Rule;
 
 pub use crate::dom::element::{Element, ElementVariant};
 pub use crate::dom::node::Node;
+pub use crate::dom::span::SourceSpan;
 pub use crate::dom::Dom;
 pub use crate::dom::DomVariant;
 pub use crate::error::Error;


### PR DESCRIPTION
`SourceSpan` is available through `Element::source_span`, however it is impossible to name the type when consuming the library as it is not public.

My motivating usecase is saving the span alongside custom validation errors to present in CLI output.