### PR TITLE
fix: keep empty text elements

### DIFF
--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -130,8 +130,12 @@ impl Dom {
                     if dom.tree_type == DomVariant::Empty {
                         dom.tree_type = DomVariant::DocumentFragment;
                     }
+
                     let text = pair.as_str().to_string();
-                    if !text.trim().is_empty() {
+                    if !text
+                        .trim_matches(|c: char| c.is_whitespace() && c != ' ')
+                        .is_empty()
+                    {
                         dom.children.push(Node::Text(text));
                     }
                 }

--- a/tests/snapshots/text__it_can_parse_text_with_only_spaces_between_elements.snap
+++ b/tests/snapshots/text__it_can_parse_text_with_only_spaces_between_elements.snap
@@ -1,0 +1,34 @@
+---
+source: tests/text.rs
+expression: dom
+---
+{
+  "treeType": "documentFragment",
+  "children": [
+    "This is a ",
+    {
+      "name": "b",
+      "variant": "normal",
+      "children": [
+        "para"
+      ]
+    },
+    " ",
+    {
+      "name": "b",
+      "variant": "normal",
+      "children": [
+        "ph"
+      ]
+    },
+    " with some",
+    {
+      "name": "i",
+      "variant": "normal",
+      "children": [
+        " weird "
+      ]
+    },
+    " formatting."
+  ]
+}

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -49,11 +49,21 @@ fn it_can_parse_text_with_chevron() -> Result<()> {
 
 #[test]
 fn it_can_parse_text_in_paragraph_with_weird_formatting() -> Result<()> {
-    let html = indoc!(r"
+    let html = indoc!(
+        r"
         <p>
             This is a <b>para</b>gra<b>ph</b> with some<i> weird </i> formatting.
         </p>
-    ");
+    "
+    );
+    let dom = Dom::parse(html)?;
+    assert_json_snapshot!(dom);
+    Ok(())
+}
+
+#[test]
+fn it_can_parse_text_with_only_spaces_between_elements() -> Result<()> {
+    let html = indoc!(r"This is a <b>para</b> <b>ph</b> with some<i> weird </i> formatting.");
     let dom = Dom::parse(html)?;
     assert_json_snapshot!(dom);
     Ok(())


### PR DESCRIPTION
Text elements with only spaces (like the one between two tags) should not be removed. I'm new to Pest so I hope that the proposed change makes sense. Don't hesitate if you want me to do it differently.

It fixes the problem in this comment: https://github.com/mathiversen/html-parser/pull/23/files/4b2e40933fb2080322537af11bea917b2d2e2781#r923896152